### PR TITLE
fix: wait for google libraries to load before using them

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@angular/platform-browser-dynamic": "^16.2.0",
         "@angular/router": "^16.2.0",
         "@angular/service-worker": "^16.2.0",
+        "@googlemaps/js-api-loader": "^1.16.2",
         "geofire-common": "^6.0.0",
         "marked": "^4.3.0",
         "ngx-markdown": "^16.0.0",
@@ -3507,6 +3508,14 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.10.1.tgz",
       "integrity": "sha512-Dq5rYfEpdeel0bLVN+nfD1VWmzCkK+pJbSjIawGE+RY4+NIJqhbUDDQjvV0NUK84fMfwxvtFoCtEe70HfZjFcw=="
+    },
+    "node_modules/@googlemaps/js-api-loader": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.2.tgz",
+      "integrity": "sha512-psGw5u0QM6humao48Hn4lrChOM2/rA43ZCm3tKK9qQsEj1/VzqkCqnvGfEOshDbBQflydfaRovbKwZMF4AyqbA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      }
     },
     "node_modules/@grpc/grpc-js": {
       "version": "1.7.3",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@angular/platform-browser-dynamic": "^16.2.0",
     "@angular/router": "^16.2.0",
     "@angular/service-worker": "^16.2.0",
+    "@googlemaps/js-api-loader": "^1.16.2",
     "geofire-common": "^6.0.0",
     "marked": "^4.3.0",
     "ngx-markdown": "^16.0.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -44,7 +44,7 @@ import { MatChipsModule } from '@angular/material/chips';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
-import { LocationautocompleteComponent } from './location-autocomplete/location-autocomplete.component';
+import { LocationAutocompleteComponent } from './location-autocomplete/location-autocomplete.component';
 
 @NgModule({
   declarations: [
@@ -54,7 +54,7 @@ import { LocationautocompleteComponent } from './location-autocomplete/location-
     HomeComponent,
     ActivityComponent,
     ActivityEditComponent,
-    LocationautocompleteComponent,
+    LocationAutocompleteComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -35,8 +35,8 @@ export class HomeComponent {
 
   constructor(
     private shService: ScreenHushService,
-    private geolocationService: GeolocationService, 
     private router: Router,
+    private geolocationService: GeolocationService
   ) {
     this.allTags = shService.getAllTags();
 

--- a/src/app/location-autocomplete/location-autocomplete.component.html
+++ b/src/app/location-autocomplete/location-autocomplete.component.html
@@ -1,6 +1,6 @@
 <form class="autocomplete-form">
     <p>Enter a location</p>
-    <mat-form-field class="autocomplete-input">
+    <mat-form-field *ngIf="isGoogleLibrariesLoaded" class="autocomplete-input">
         <mat-label>Location</mat-label>
         <input type="text" placeholder="Search for a location" matInput [formControl]="searchInput" [matAutocomplete]="auto">
         <mat-error *ngIf="searchInput.hasError('serverError')">{{getErrorMessage()}}</mat-error>

--- a/src/app/location-autocomplete/location-autocomplete.component.spec.ts
+++ b/src/app/location-autocomplete/location-autocomplete.component.spec.ts
@@ -1,12 +1,12 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
-import { LocationautocompleteComponent } from './location-autocomplete.component';
+import { LocationAutocompleteComponent } from './location-autocomplete.component';
 import { GeolocationService } from '../services/geolocation.service';
 import { of } from 'rxjs';
 
-describe('LocationautocompleteComponent', () => {
-  let component: LocationautocompleteComponent;
-  let fixture: ComponentFixture<LocationautocompleteComponent>;
+describe('LocationAutocompleteComponent', () => {
+  let component: LocationAutocompleteComponent;
+  let fixture: ComponentFixture<LocationAutocompleteComponent>;
 
   // Create a mock service with a mocked getPredictions method
   const geolocationServiceMock = {
@@ -15,13 +15,13 @@ describe('LocationautocompleteComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [LocationautocompleteComponent],
+      declarations: [LocationAutocompleteComponent],
       imports: [ReactiveFormsModule],
       providers: [
         { provide: GeolocationService, useValue: geolocationServiceMock },
       ],
     });
-    fixture = TestBed.createComponent(LocationautocompleteComponent);
+    fixture = TestBed.createComponent(LocationAutocompleteComponent);a
     component = fixture.componentInstance;
   });
 

--- a/src/app/location-autocomplete/location-autocomplete.component.ts
+++ b/src/app/location-autocomplete/location-autocomplete.component.ts
@@ -1,22 +1,28 @@
 import { Component, Output, EventEmitter, OnInit } from '@angular/core';
-import { FormControl, FormGroupDirective, NgForm, Validators } from '@angular/forms';
-import { GeolocationService } from '../services/geolocation.service';
-import { Observable, switchMap, of } from 'rxjs';
-import { catchError, map, startWith } from 'rxjs/operators';
+import { FormControl } from '@angular/forms';
+import { Observable, switchMap, of, BehaviorSubject } from 'rxjs';
+import { catchError, startWith } from 'rxjs/operators';
 import { AutocompleteResult } from '../model/autocomplete-result.model';
+import { GoogleLoaderService } from '../services/google-loader.service';
+import { GeolocationService } from '../services/geolocation.service';
 
 @Component({
   selector: 'app-location-autocomplete',
   templateUrl: './location-autocomplete.component.html',
   styleUrls: ['./location-autocomplete.component.scss'],
 })
-export class LocationautocompleteComponent {
+export class LocationAutocompleteComponent {
   @Output() selectedLocation = new EventEmitter<AutocompleteResult>();
-  constructor(private geolocationService: GeolocationService) {}
+  constructor(private geolocationService: GeolocationService, private googleLoaderService: GoogleLoaderService) {}
   suggestions: Observable<AutocompleteResult[]>;
   searchInput = new FormControl('');
+  isGoogleLibrariesLoaded: boolean = false;
 
   ngOnInit() {
+    this.googleLoaderService.onGooglelibrariesDidLoad$.subscribe((loaded) => {
+      this.isGoogleLibrariesLoaded = loaded;
+    });
+            
     this.suggestions = this.searchInput.valueChanges.pipe(
       startWith(''),
       switchMap((value) => this.geolocationService.getPredictions(value)),

--- a/src/app/services/geolocation.service.ts
+++ b/src/app/services/geolocation.service.ts
@@ -1,16 +1,17 @@
 import { Injectable } from '@angular/core';
-import { Observable, defer, from } from 'rxjs';
+import { Observable, defer, from, switchMap } from 'rxjs';
 import { AutocompleteResult } from '../model/autocomplete-result.model';
 import { GeoLocationResult } from '../model/geolocation-result.model';
+import { GoogleLoaderService } from './google-loader.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class GeolocationService {
-  private autocompleteService = new google.maps.places.AutocompleteService();
-  private geocoder = new google.maps.Geocoder();
   private defaultLocations = [];
   private defaultGeolocationResult = [{ latitude: 0, longitude: 0 }];
+
+  constructor(private googleLoader: GoogleLoaderService) {}
 
   getPredictions(input: string | null): Observable<AutocompleteResult[]> {
     return defer(() => {
@@ -22,20 +23,29 @@ export class GeolocationService {
             input,
             componentRestrictions: { country: 'au' },
             types: ['administrative_area_level_1', 'locality', 'postal_code'],
-            fields: ['place_id', 'description']
-          }
-          this.autocompleteService.getPlacePredictions(request, (predictions, status) => {
-            if (status !== google.maps.places.PlacesServiceStatus.OK || !predictions) {
-              console.error('Error fetching predictions');
-            } else {
-              const suggestions: AutocompleteResult[] = predictions.map((prediction) => ({
-                placeId: prediction.place_id,
-                description: prediction.description,
-              }));
-              observer.next(suggestions);
+            fields: ['place_id', 'description'],
+          };
+          this.googleLoader.autocompleteService.getPlacePredictions(
+            request,
+            (predictions, status) => {
+              if (
+                status !== google.maps.places.PlacesServiceStatus.OK ||
+                !predictions
+              ) {
+                observer.error('Error fetching predictions');
+                console.error('Error fetching predictions');
+              } else {
+                const suggestions: AutocompleteResult[] = predictions.map(
+                  (prediction) => ({
+                    placeId: prediction.place_id,
+                    description: prediction.description,
+                  })
+                );
+                observer.next(suggestions);
+              }
+              observer.complete();
             }
-            observer.complete();
-          });
+          );
         });
       }
     });
@@ -46,17 +56,20 @@ export class GeolocationService {
       if (placeId === null) {
         reject(this.defaultGeolocationResult);
       } else {
-        this.geocoder.geocode({ placeId }, (geocoderResult, status) => {
-          if (status !== google.maps.GeocoderStatus.OK || !geocoderResult) {
-            resolve(this.defaultGeolocationResult);
-          } else {
-            const result = geocoderResult.map((res) => ({
-              latitude: res.geometry.location.lat(),
-              longitude: res.geometry.location.lng(),
-            }));
-            resolve(result);
+        this.googleLoader.geoCodingService.geocode(
+          { placeId },
+          (geocoderResult, status) => {
+            if (status !== google.maps.GeocoderStatus.OK || !geocoderResult) {
+              resolve(this.defaultGeolocationResult);
+            } else {
+              const result = geocoderResult.map((res) => ({
+                latitude: res.geometry.location.lat(),
+                longitude: res.geometry.location.lng(),
+              }));
+              resolve(result);
+            }
           }
-        });
+        );
       }
     });
   }

--- a/src/app/services/google-loader.service.ts
+++ b/src/app/services/google-loader.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+import { Loader } from '@googlemaps/js-api-loader';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class GoogleLoaderService {
+  onGooglelibrariesDidLoad$ = new BehaviorSubject<boolean>(false);
+  private loader: Loader;
+  geoCodingService: google.maps.Geocoder;
+  autocompleteService: google.maps.places.AutocompleteService;
+
+  constructor() {
+    this.loader = new Loader({
+      apiKey: "[APIKEY]",
+      version: "weekly",
+      libraries: ["places", "geocoding"]
+    });
+
+    this.loadLibraries();
+  }
+
+  private async loadLibraries(): Promise<void> {
+    const geocodingPromise = this.loader.importLibrary('geocoding');
+    const placesPromise = this.loader.importLibrary('places');
+
+    return Promise.all([geocodingPromise, placesPromise])
+      .then(() => {
+        this.geoCodingService = new google.maps.Geocoder();
+        this.autocompleteService = new google.maps.places.AutocompleteService();
+
+        this.onGooglelibrariesDidLoad$.next(true);
+      })
+      .catch((e) => {
+        this.onGooglelibrariesDidLoad$.next(false);
+        console.log("Error loading google libraries");
+      });
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -12,7 +12,6 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#1976d2">
-  <script async src="https://maps.googleapis.com/maps/api/js?key=[API_KEY]&libraries=places"></script>
 </head>
 
 <body class="mat-typography">


### PR DESCRIPTION
Sometimes location search does not return results and it may be due to the libraries not being available before its used.

- Switched to  `js-api-loader` instead of script. APIKEY could be injected from Firebase for extra security.
- Added GoogleLoaderService that will notify once Google libraries have loaded.